### PR TITLE
Fix code coverage

### DIFF
--- a/tests/components/zha/test_cover.py
+++ b/tests/components/zha/test_cover.py
@@ -3,7 +3,9 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from zigpy.const import SIG_ENDPOINTS
 import zigpy.profiles.zha
+from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types
 import zigpy.zcl.clusters.closures as closures
 import zigpy.zcl.clusters.general as general
@@ -443,3 +445,62 @@ async def test_cover_remote(hass, zha_device_joined_restored, zigpy_cover_remote
 
     assert len(zha_events) == 2
     assert zha_events[1].data[ATTR_COMMAND] == "down_close"
+
+
+class TuyaCoverQuirk(CustomDevice):
+    """Quirk with 'tuya_window_covering' cluster."""
+
+    class TuyaCoveringCluster(CustomCluster, closures.WindowCovering):
+        """Tuya WindowCovering cluster."""
+
+        ep_attribute = "tuya_window_covering"
+
+        attributes = closures.WindowCovering.attributes.copy()
+        attributes.update({0xF000: ("tuya_moving_state", zigpy.types.enum8, True)})
+        attributes.update({0xF001: ("calibration", zigpy.types.enum8, True)})
+        attributes.update({0xF002: ("motor_reversal", zigpy.types.enum8, True)})
+        attributes.update({0xF003: ("calibration_time", zigpy.types.uint16_t, True)})
+
+    replacement = {
+        SIG_ENDPOINTS: {
+            1: {
+                SIG_EP_PROFILE: zigpy.profiles.zha.PROFILE_ID,
+                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.WINDOW_COVERING_DEVICE,
+                SIG_EP_INPUT: [TuyaCoveringCluster],
+                SIG_EP_OUTPUT: [],
+            },
+        }
+    }
+
+
+@pytest.fixture
+async def tuya_window_cover(hass, zigpy_device_mock, zha_device_joined):
+    """Tuya VindowCovering fixture."""
+
+    zigpy_device = zigpy_device_mock(
+        {
+            1: {
+                SIG_EP_INPUT: [closures.WindowCovering.cluster_id],
+                SIG_EP_OUTPUT: [],
+                SIG_EP_TYPE: zigpy.profiles.zha.DeviceType.WINDOW_COVERING_DEVICE,
+            }
+        },
+        model="TS130F",
+        manufacturer="_TZE200_whatever",
+        quirk=TuyaCoverQuirk,
+    )
+
+    zha_device = await zha_device_joined(zigpy_device)
+    zha_device.available = True
+    cover_cluster = zigpy_device.endpoints[1].tuya_window_covering
+    return zha_device, cover_cluster
+
+
+async def test_tuya_window_covering(hass, tuya_window_cover):
+    """Test Tuya custom 'motor direction' ZHA select."""
+
+    zha_device, cluster = tuya_window_cover
+    assert cluster is not None
+    assert cluster.ep_attribute=="tuya_window_covering"
+    cover_entity_id = await find_entity_id(Platform.COVER, zha_device, hass)
+    assert cover_entity_id is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the test coverage for the new cover class

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
